### PR TITLE
Pool#close()

### DIFF
--- a/pool.js
+++ b/pool.js
@@ -288,6 +288,13 @@ Pool.prototype.request_count = function () {
     return this.endpoints.reduce(function (a, b) { return a + b.request_count; }, 0);
 };
 
+Pool.prototype.close = function () {
+    var endpoints = this.endpoints;
+    for (var i = 0; i < endpoints.length; i++) {
+        endpoints[i].close();
+    }
+};
+
 module.exports = function init(new_GO) {
     GO = new_GO;
 

--- a/pool_endpoint.js
+++ b/pool_endpoint.js
@@ -71,6 +71,10 @@ function PoolEndpoint(protocol, ip, port, options) {
 }
 inherits(PoolEndpoint, EventEmitter);
 
+PoolEndpoint.prototype.close = function () {
+    clearInterval(this.timeout_interval);
+};
+
 // options: {
 //   timeout: request timeout in ms (this.timeout)
 //   encoding: response body encoding (utf8)


### PR DESCRIPTION
[zag-agent](https://github.com/Voxer/zag) has a `.close()` method that closes the socket so that a service can exit gracefully. `Pool` has a pending interval timer that prevents this, though. The `close()` method clears it.
